### PR TITLE
Add fields to manage extra paramerters

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -190,6 +190,7 @@ swiftlint="${run_swiftlint}"
 tailor="on"
 lizard="on"
 oclint="${run_oclint}"
+dependencycheck="${run_dependency_check}"
 sonarscanner="on"
 
 # Usage OK
@@ -350,6 +351,10 @@ if [ "$unittests" = "on" ]; then
 	if [[ ! -z "${tests_exclusions}" ]]; then
 		sonarScannerOptions+=" -Dsonar.coverage.exclusions=${tests_exclusions}"
 	fi
+fi
+
+if [ "$dependencycheck" = "on" ]; then
+	sonarScannerOptions+=" -Dsonar.dependencyCheck.jsonReportPath=${workspaceFile}/../dependency-check-report.json"
 fi
 
 if [ -z "$BITRISE_PULL_REQUEST" ]; then

--- a/step.sh
+++ b/step.sh
@@ -364,6 +364,13 @@ echo "Switching to Pull Request mode"
   sonarScannerOptions+=" -Dsonar.pullrequest.branch=${BITRISE_GIT_BRANCH} -Dsonar.pullrequest.key=${BITRISE_PULL_REQUEST} -Dsonar.pullrequest.base=${BITRISEIO_GIT_BRANCH_DEST}"
 fi
 
+if [ -z $extras ]; then 
+    echo -n 'No extra parameter provided'
+else 
+    echo -n "Adding extra parameters: $extras"
+    sonarScannerOptions+=" ${extras}"
+fi
+
 if [ "$sonarscanner" = "on" ]; then
     echo -n 'Running SonarQube using SonarQube Scanner'
     if hash /dev/stdout sonar-scanner 2>/dev/null; then

--- a/step.yml
+++ b/step.yml
@@ -174,3 +174,10 @@ inputs:
         Enter a comma-separated list of files to exclude from the scan. You can use wilcards.
       is_expand: true
       is_required: true
+  - extras: ""
+    opts:
+      title: "Extra Parameters"
+      description: |
+        Add extra parameters to provide to the `sonar-scanner` command (e.g. `-D sonar.foo=bar`)
+      is_expand: true
+      is_required: false

--- a/step.yml
+++ b/step.yml
@@ -167,6 +167,16 @@ inputs:
       value_options:
         - "on"
         - "off"
+  - run_dependency_check: "on"
+    opts:
+      title: "Use dependency check"
+      description: |
+        Wether or not to use dependency check as part of the scan.
+      is_expand: true
+      is_required: true
+      value_options:
+        - "on"
+        - "off"
   - exclusions: "**/*.xml,**/Pods/**/*,Reports/**/*"
     opts:
       title: "Exclusions"


### PR DESCRIPTION
The purpose of this feature is to add extra parameters to the `sonar-scanner` command. 